### PR TITLE
Version 2.3.3

### DIFF
--- a/Assets/Zifro Playground UI/Editor/ZifroPlayground.UI.Editor.AssemblyInfo.cs
+++ b/Assets/Zifro Playground UI/Editor/ZifroPlayground.UI.Editor.AssemblyInfo.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.3.2")]
-[assembly: AssemblyFileVersion("2.3.2")]
-[assembly: AssemblyInformationalVersion("2.3.2")]
+[assembly: AssemblyVersion("2.3.3")]
+[assembly: AssemblyFileVersion("2.3.3")]
+[assembly: AssemblyInformationalVersion("2.3.3")]

--- a/Assets/Zifro Playground UI/Miscellaneous/ZifroPlaygroundUIAssemblyInfo.cs
+++ b/Assets/Zifro Playground UI/Miscellaneous/ZifroPlaygroundUIAssemblyInfo.cs
@@ -3,9 +3,9 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using UnityEngine;
 
-[assembly: AssemblyVersion("2.3.2")]
-[assembly: AssemblyFileVersion("2.3.2")]
-[assembly: AssemblyInformationalVersion("2.3.2")]
+[assembly: AssemblyVersion("2.3.3")]
+[assembly: AssemblyFileVersion("2.3.3")]
+[assembly: AssemblyInformationalVersion("2.3.3")]
 
 namespace PM
 {

--- a/Assets/Zifro Playground UI/Tests/Tests.EditMode/ZifroPlayground.UI.Tests.EditMode.AssemblyInfo.cs
+++ b/Assets/Zifro Playground UI/Tests/Tests.EditMode/ZifroPlayground.UI.Tests.EditMode.AssemblyInfo.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.3.2")]
-[assembly: AssemblyFileVersion("2.3.2")]
-[assembly: AssemblyInformationalVersion("2.3.2")]
+[assembly: AssemblyVersion("2.3.3")]
+[assembly: AssemblyFileVersion("2.3.3")]
+[assembly: AssemblyInformationalVersion("2.3.3")]

--- a/Assets/Zifro Playground UI/Tests/ZifroPlayground.UI.Tests.AssemblyInfo.cs
+++ b/Assets/Zifro Playground UI/Tests/ZifroPlayground.UI.Tests.AssemblyInfo.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.3.2")]
-[assembly: AssemblyFileVersion("2.3.2")]
-[assembly: AssemblyInformationalVersion("2.3.2")]
+[assembly: AssemblyVersion("2.3.3")]
+[assembly: AssemblyFileVersion("2.3.3")]
+[assembly: AssemblyInformationalVersion("2.3.3")]

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -118,7 +118,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 2.3.2
+  bundleVersion: 2.3.3
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
Contains small fix of removing usage of UnityEditor namespace. Should be all safe now.