### PR TITLE
Version 2.5.1, major Mellis changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       SCRIPTS: /root/repo/ci/scripts/
 
     docker:
-      - image: zifrose/unity3d:2019.1.1f2
+      - image: zifrose/unity3d:2019.1.1f1
         
     steps:
       - add_ssh_keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       SCRIPTS: /root/repo/ci/scripts/
 
     docker:
-      - image: zifrose/unity3d:2019.1.0f2
+      - image: zifrose/unity3d:2019.1.1f2
         
     steps:
       - add_ssh_keys:

--- a/Assets/Zifro Playground UI/CodeWalker/CodeWalker.cs
+++ b/Assets/Zifro Playground UI/CodeWalker/CodeWalker.cs
@@ -16,6 +16,7 @@ namespace PM
 			new AbsoluteValue(),
 			new ConvertToBinary(),
 			new ConvertToHexadecimal(),
+			new ConvertToOctal(),
 			new LengthOf(),
 			new RoundedValue(),
 			new MinimumValue(),

--- a/Assets/Zifro Playground UI/Core/LevelAnswer.cs
+++ b/Assets/Zifro Playground UI/Core/LevelAnswer.cs
@@ -1,15 +1,15 @@
 ﻿using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using Mellis.Core.Interfaces;
 using UnityEngine;
-using UnityEngine.UI;
 
 namespace PM
 {
 	public abstract class LevelAnswer
 	{
 		public bool compilerHasBeenStopped;
+
+		public abstract void CheckAnswer(IScriptType[] inputParams);
 
 		protected IEnumerator ShowAnswerBubble(string answer, bool correct)
 		{
@@ -47,18 +47,16 @@ namespace PM
 			}
 		}
 
-		private void AbortCase()
+		void AbortCase()
 		{
 			UISingleton.instance.answerBubble.HideMessage();
 			Main.instance.caseHandler.ResetHandlerAndButtons();
 		}
-
-		public abstract void CheckAnswer(IScriptType[] inputParams);
 	}
 
 	public class LevelAnswer<T> : LevelAnswer
 	{
-		private readonly T[] expectedInputs;
+		readonly T[] expectedInputs;
 
 		public LevelAnswer(params T[] expectedInputs)
 		{
@@ -94,34 +92,57 @@ namespace PM
 				IScriptType input = inputParams[i];
 				T expected = expectedInputs[i];
 
-				if (!input.TryConvert(out T actual))
+				if (typeof(T) == typeof(string))
 				{
-					if (typeof(T) == typeof(bool))
+					if (!(input is IScriptString actual))
 					{
 						PMWrapper.RaiseError($"Fel typ, svar nr {i + 1} ska vara True eller False.");
 					}
-					else if (typeof(T) == typeof(int))
+					else if (expected.Equals(actual.Value))
+					{
+						correctAnswer = false;
+						break;
+					}
+				}
+				else if (typeof(T) == typeof(int))
+				{
+					if (!(input is IScriptInteger actual))
 					{
 						PMWrapper.RaiseError($"Fel typ, svar nr {i + 1} ska vara ett heltal.");
 					}
-					else if (typeof(T) == typeof(double))
+					else if (expected.Equals(actual.Value))
+					{
+						correctAnswer = false;
+						break;
+					}
+				}
+				else if (typeof(T) == typeof(double))
+				{
+					if (!(input is IScriptDouble actual))
 					{
 						PMWrapper.RaiseError($"Fel typ, svar nr {i + 1} ska vara ett tal.");
 					}
-					else if (typeof(T) == typeof(string))
+					else if (expected.Equals(actual.Value))
+					{
+						correctAnswer = false;
+						break;
+					}
+				}
+				else if (typeof(T) == typeof(bool))
+				{
+					if (!(input is IScriptBoolean actual))
 					{
 						PMWrapper.RaiseError($"Fel typ, svar nr {i + 1} ska vara en textsträng.");
 					}
-					else
+					else if (expected.Equals(actual.Value))
 					{
-						PMWrapper.RaiseError($"Fel typ på svar nr {i + 1}.");
+						correctAnswer = false;
+						break;
 					}
 				}
-
-				if (!expected.Equals(actual))
+				else
 				{
-					correctAnswer = false;
-					break;
+					PMWrapper.RaiseError($"Fel typ på svar nr {i + 1}.");
 				}
 			}
 

--- a/Assets/Zifro Playground UI/Core/LevelAnswer.cs
+++ b/Assets/Zifro Playground UI/Core/LevelAnswer.cs
@@ -60,7 +60,7 @@ namespace PM
 
 		public LevelAnswer(params T[] expectedInputs)
 		{
-			Debug.LogFormat("Expecting answers: {0}", string.Join(", ", expectedInputs));
+			Debug.LogFormat("Expecting answers ({0}): {1}", typeof(T).Name, string.Join(", ", expectedInputs));
 			this.expectedInputs = expectedInputs;
 		}
 
@@ -98,7 +98,7 @@ namespace PM
 					{
 						PMWrapper.RaiseError($"Fel typ, svar nr {i + 1} ska vara True eller False.");
 					}
-					else if (expected.Equals(actual.Value))
+					else if (!expected.Equals(actual.Value))
 					{
 						correctAnswer = false;
 						break;
@@ -110,7 +110,7 @@ namespace PM
 					{
 						PMWrapper.RaiseError($"Fel typ, svar nr {i + 1} ska vara ett heltal.");
 					}
-					else if (expected.Equals(actual.Value))
+					else if (!expected.Equals(actual.Value))
 					{
 						correctAnswer = false;
 						break;
@@ -122,7 +122,7 @@ namespace PM
 					{
 						PMWrapper.RaiseError($"Fel typ, svar nr {i + 1} ska vara ett tal.");
 					}
-					else if (expected.Equals(actual.Value))
+					else if (!expected.Equals(actual.Value))
 					{
 						correctAnswer = false;
 						break;
@@ -134,7 +134,7 @@ namespace PM
 					{
 						PMWrapper.RaiseError($"Fel typ, svar nr {i + 1} ska vara en textsträng.");
 					}
-					else if (expected.Equals(actual.Value))
+					else if (!expected.Equals(actual.Value))
 					{
 						correctAnswer = false;
 						break;
@@ -147,6 +147,8 @@ namespace PM
 			}
 
 			string joined = string.Join(", ", inputParams.Select(o => o.ToString()));
+
+			Debug.LogFormat("Received answers: {0}\nCorrect? {1}", string.Join(", ", inputParams.Select(o => $"{o} ({o.GetTypeName()})")), correctAnswer);
 
 			Main.instance.StartCoroutine(ShowAnswerBubble(joined, correctAnswer));
 		}

--- a/Assets/Zifro Playground UI/Editor/ZifroPlayground.UI.Editor.AssemblyInfo.cs
+++ b/Assets/Zifro Playground UI/Editor/ZifroPlayground.UI.Editor.AssemblyInfo.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.2")]
-[assembly: AssemblyFileVersion("2.4.2")]
-[assembly: AssemblyInformationalVersion("2.4.2")]
+[assembly: AssemblyVersion("2.5.0")]
+[assembly: AssemblyFileVersion("2.5.0")]
+[assembly: AssemblyInformationalVersion("2.5.0")]

--- a/Assets/Zifro Playground UI/Editor/ZifroPlayground.UI.Editor.AssemblyInfo.cs
+++ b/Assets/Zifro Playground UI/Editor/ZifroPlayground.UI.Editor.AssemblyInfo.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.5.0")]
-[assembly: AssemblyFileVersion("2.5.0")]
-[assembly: AssemblyInformationalVersion("2.5.0")]
+[assembly: AssemblyVersion("2.5.1")]
+[assembly: AssemblyFileVersion("2.5.1")]
+[assembly: AssemblyInformationalVersion("2.5.1")]

--- a/Assets/Zifro Playground UI/IDE/Text Field/Color Coding/IDEColorCoding.cs
+++ b/Assets/Zifro Playground UI/IDE/Text Field/Color Coding/IDEColorCoding.cs
@@ -484,8 +484,8 @@ namespace PM
 					}
 
 					if (index >= text.Length ||
-						text[index] != 'j' &&
-						text[index] != 'J')
+						(text[index] != 'j' &&
+						text[index] != 'J'))
 					{
 						index = startIndex;
 						return null;
@@ -610,9 +610,9 @@ namespace PM
 
 					bool IsHexadecimal(char c)
 					{
-						return c >= '0' && c <= '9' ||
-							   c >= 'a' && c <= 'f' ||
-							   c >= 'A' && c <= 'A';
+						return (c >= '0' && c <= '9') ||
+							   (c >= 'a' && c <= 'f') ||
+							   (c >= 'A' && c <= 'A');
 					}
 
 					string BIN_INTEGER()
@@ -756,7 +756,10 @@ namespace PM
 		private static string ColorKeyWords(string text)
 		{
 			if (keyWords.Contains(text))
+			{
 				return string.Format("<color={0}>{1}</color>", keyWordsColor, text);
+			}
+
 			return text;
 		}
 

--- a/Assets/Zifro Playground UI/IDE/VariableWindow/VariableInWindow.cs
+++ b/Assets/Zifro Playground UI/IDE/VariableWindow/VariableInWindow.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using Mellis.Core.Interfaces;
-using Mellis.Lang.Base.Entities;
 using PM;
 using UnityEngine;
 using UnityEngine.UI;

--- a/Assets/Zifro Playground UI/IDE/VariableWindow/VariableWindow.cs
+++ b/Assets/Zifro Playground UI/IDE/VariableWindow/VariableWindow.cs
@@ -46,7 +46,7 @@ namespace PM
 			{
 				VariableInWindow clone = Instantiate(variablePrefab, contentRect.transform, false);
 
-				string valueString = variable.ToString();
+				string valueString = variable.Value.ToString();
 
 				float width = CalcVariableWidth(Mathf.Max(variable.Key.Length, valueString.Length));
 				int maxChars = CalcNoCharacters(width);

--- a/Assets/Zifro Playground UI/IDE/VariableWindow/VariableWindow.cs
+++ b/Assets/Zifro Playground UI/IDE/VariableWindow/VariableWindow.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using System;
+using Mellis;
 using Mellis.Core.Interfaces;
-using Mellis.Lang.Base.Entities;
 
 namespace PM
 {
@@ -42,18 +42,18 @@ namespace PM
 
 			currentVariables.Clear();
 
-			foreach (IScriptType variable in processor.CurrentScope.Variables.Values)
+			foreach (KeyValuePair<string, IScriptType> variable in processor.CurrentScope.Variables)
 			{
 				VariableInWindow clone = Instantiate(variablePrefab, contentRect.transform, false);
 
 				string valueString = variable.ToString();
 
-				float width = CalcVariableWidth(Mathf.Max(variable.Name.Length, valueString.Length));
+				float width = CalcVariableWidth(Mathf.Max(variable.Key.Length, valueString.Length));
 				int maxChars = CalcNoCharacters(width);
 				clone.SetWidth(width);
 
-				ToStringAndCompressVariable(variable, valueString, maxChars, out valueString, out Color valueColor);
-				clone.InitVariable(variable.Name, nameTextColor, valueString, valueColor);
+				ToStringAndCompressVariable(variable.Value, valueString, maxChars, out valueString, out Color valueColor);
+				clone.InitVariable(variable.Key, nameTextColor, valueString, valueColor);
 
 				currentVariables.Add(clone);
 			}
@@ -99,23 +99,23 @@ namespace PM
 		{
 			switch (variable)
 			{
-			case BooleanBase _:
+			case IScriptBoolean _:
 				color = boolText;
 				text = CompressString(s, maxChars);
 				break;
 
-			case IntegerBase _:
-			case DoubleBase _:
+			case IScriptInteger _:
+			case IScriptDouble _:
 				color = numberText;
 				text = CompressString(s, maxChars, isNumberValue: true);
 				break;
 
-			case StringBase _:
+			case IScriptString _:
 				color = stringText;
 				text = CompressString(s, maxChars, isStringValue: true);
 				break;
 
-			case NullBase _:
+			case ScriptNull _:
 				color = nullText;
 				text = variable.ToString();
 				break;

--- a/Assets/Zifro Playground UI/Miscellaneous/ZifroPlaygroundUIAssemblyInfo.cs
+++ b/Assets/Zifro Playground UI/Miscellaneous/ZifroPlaygroundUIAssemblyInfo.cs
@@ -3,9 +3,9 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using UnityEngine;
 
-[assembly: AssemblyVersion("2.5.0")]
-[assembly: AssemblyFileVersion("2.5.0")]
-[assembly: AssemblyInformationalVersion("2.5.0")]
+[assembly: AssemblyVersion("2.5.1")]
+[assembly: AssemblyFileVersion("2.5.1")]
+[assembly: AssemblyInformationalVersion("2.5.1")]
 
 namespace PM
 {

--- a/Assets/Zifro Playground UI/Miscellaneous/ZifroPlaygroundUIAssemblyInfo.cs
+++ b/Assets/Zifro Playground UI/Miscellaneous/ZifroPlaygroundUIAssemblyInfo.cs
@@ -3,9 +3,9 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using UnityEngine;
 
-[assembly: AssemblyVersion("2.4.2")]
-[assembly: AssemblyFileVersion("2.4.2")]
-[assembly: AssemblyInformationalVersion("2.4.2")]
+[assembly: AssemblyVersion("2.5.0")]
+[assembly: AssemblyFileVersion("2.5.0")]
+[assembly: AssemblyInformationalVersion("2.5.0")]
 
 namespace PM
 {

--- a/Assets/Zifro Playground UI/Tests/Tests.EditMode/ZifroPlayground.UI.Tests.EditMode.AssemblyInfo.cs
+++ b/Assets/Zifro Playground UI/Tests/Tests.EditMode/ZifroPlayground.UI.Tests.EditMode.AssemblyInfo.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.2")]
-[assembly: AssemblyFileVersion("2.4.2")]
-[assembly: AssemblyInformationalVersion("2.4.2")]
+[assembly: AssemblyVersion("2.5.0")]
+[assembly: AssemblyFileVersion("2.5.0")]
+[assembly: AssemblyInformationalVersion("2.5.0")]

--- a/Assets/Zifro Playground UI/Tests/Tests.EditMode/ZifroPlayground.UI.Tests.EditMode.AssemblyInfo.cs
+++ b/Assets/Zifro Playground UI/Tests/Tests.EditMode/ZifroPlayground.UI.Tests.EditMode.AssemblyInfo.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.5.0")]
-[assembly: AssemblyFileVersion("2.5.0")]
-[assembly: AssemblyInformationalVersion("2.5.0")]
+[assembly: AssemblyVersion("2.5.1")]
+[assembly: AssemblyFileVersion("2.5.1")]
+[assembly: AssemblyInformationalVersion("2.5.1")]

--- a/Assets/Zifro Playground UI/Tests/ZifroPlayground.UI.Tests.AssemblyInfo.cs
+++ b/Assets/Zifro Playground UI/Tests/ZifroPlayground.UI.Tests.AssemblyInfo.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.4.2")]
-[assembly: AssemblyFileVersion("2.4.2")]
-[assembly: AssemblyInformationalVersion("2.4.2")]
+[assembly: AssemblyVersion("2.5.0")]
+[assembly: AssemblyFileVersion("2.5.0")]
+[assembly: AssemblyInformationalVersion("2.5.0")]

--- a/Assets/Zifro Playground UI/Tests/ZifroPlayground.UI.Tests.AssemblyInfo.cs
+++ b/Assets/Zifro Playground UI/Tests/ZifroPlayground.UI.Tests.AssemblyInfo.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.5.0")]
-[assembly: AssemblyFileVersion("2.5.0")]
-[assembly: AssemblyInformationalVersion("2.5.0")]
+[assembly: AssemblyVersion("2.5.1")]
+[assembly: AssemblyFileVersion("2.5.1")]
+[assembly: AssemblyInformationalVersion("2.5.1")]

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -35,7 +35,7 @@
   },
   "lock": {
     "se.zifro.mellis": {
-      "hash": "70fbac48112243a3ac2066ba0a3b9cfd0076a711",
+      "hash": "e0e56d26d37dfeaed440f6369402a421a49c26a6",
       "revision": "upm"
     }
   }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -118,7 +118,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 2.5.0
+  bundleVersion: 2.5.1
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -118,7 +118,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 2.4.2
+  bundleVersion: 2.5.0
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.1.0f2
-m_EditorVersionWithRevision: 2019.1.0f2 (292b93d75a2c)
+m_EditorVersion: 2019.1.1f1
+m_EditorVersionWithRevision: 2019.1.1f1 (fef62e97e63b)

--- a/ci/build-and-push-docker.ps1
+++ b/ci/build-and-push-docker.ps1
@@ -22,7 +22,7 @@ param(
 
     # Unity version, also used as Docker image tag
     [string]
-    $UnityVersion = "2018.3.11f1"
+    $UnityVersion = "2019.1.1f1"
 )
 
 function GetBaseImage ([string] $Image, [string] $Version) {

--- a/ci/unity3d.Dockerfile
+++ b/ci/unity3d.Dockerfile
@@ -1,5 +1,5 @@
 
-ARG UNITY_VERSION=2018.3.11f1-unity
+ARG UNITY_VERSION=2019.1.1f1-unity
 FROM gableroux/unity3d:${UNITY_VERSION}
 
 # Add trusted sources


### PR DESCRIPTION
- Updates used Unity version in both repo and CI to 2019.1.1f1.
- Updated Mellis to 0.4.4 & Python3 module to 0.8.7. News include:
  - Filled out most operators for the base types (unary minus, byte operators, integer exponentiation, etc)
  - Handling reversed operators (ex: str can define str*int & int*str) and thereby supporting commutative operators.
  - Augmented assignments, i.e. "in-place" operators (ex: +=, -=, *=, etc.)
  - **[Backwards incompatible]** Removed `TryConvert/TryCoerce`, now instead check if type is `IScriptInteger`, `IScriptDouble`, `IScriptString`, `IScriptBoolean`. Then use the `IScript*.Value` property to access the values.
  - **[Backwards incompatible]** Removed `IScriptType.Name`. Variables no longer keep track of their own name. This is future-proofing solutions to later allows value caching.
  - **[Backwards incompatible]** Removed `IScriptType.Copy()`, as its only use was to track the variable names.
- Upped version of UI to `2.5.1`